### PR TITLE
Use argument forwarding operator for add_provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.3', '2.7', '3.0', '3.1']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ your default settings with a user configuration file and let those be overridden
 by environment variables. The query interface allows to group and nest your configuration options
 to a practically unlimited level.
 
-Configurate supports Ruby 2.3 or later.
+Configurate supports Ruby 2.7 or later.
 
 ## Installation
 

--- a/configurate.gemspec
+++ b/configurate.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files    = Dir["spec/**/*.rb"]
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = ">= 2.3.0"
+  s.required_ruby_version = ">= 2.7.0"
 
   s.add_development_dependency "rake",  ">= 10.0.3"
   s.add_development_dependency "rspec", ">= 3.0"

--- a/lib/configurate/lookup_chain.rb
+++ b/lib/configurate/lookup_chain.rb
@@ -12,15 +12,15 @@ module Configurate
     # they are added, so the order is important.
     #
     # @param provider [#lookup]
-    # @param *args the arguments passed to the providers constructor
+    # @param ... the arguments passed to the providers constructor
     # @raise [ArgumentError] if an invalid provider is given
     # @return [void]
-    def add_provider(provider, *args)
+    def add_provider(provider, ...)
       unless provider.respond_to?(:instance_methods) && provider.instance_methods.include?(:lookup)
         raise ArgumentError, "the given provider does not respond to lookup"
       end
 
-      @provider << provider.new(*args)
+      @provider << provider.new(...)
     end
 
     # Tries all providers in the order they were added to provide a response
@@ -31,11 +31,11 @@ module Configurate
     # @param ... further args passed to the provider
     # @return [Array,Hash,String,Boolean,nil] whatever the responding
     #   provider provides is casted to a {String}, except for some special values
-    def lookup(setting, *args)
+    def lookup(setting, ...)
       setting = SettingPath.new setting if setting.is_a? String
       @provider.each do |provider|
         begin
-          return special_value_or_string(provider.lookup(setting.clone, *args))
+          return special_value_or_string(provider.lookup(setting.clone, ...))
         rescue SettingNotFoundError; end
       end
 

--- a/spec/configurate/lookup_chain_spec.rb
+++ b/spec/configurate/lookup_chain_spec.rb
@@ -27,6 +27,11 @@ describe Configurate::LookupChain do
       expect(ValidConfigurationProvider).to receive(:new).with(:extra)
       subject.add_provider ValidConfigurationProvider, :extra
     end
+
+    it "passes keyword args to the provider" do
+      expect(ValidConfigurationProvider).to receive(:new).with(required: false)
+      subject.add_provider ValidConfigurationProvider, required: false
+    end
   end
 
   describe "#lookup" do


### PR DESCRIPTION
This resolves an `ArgumentError` I had with using `configurate` with Ruby 3.2.  For some reason this was still fine until Ruby 3.1:

```ruby
# frozen_string_literal: true

require 'configurate'
require 'configurate/provider/toml'

Config = Configurate::Settings.create do
  add_provider Configurate::Provider::Env
  add_provider Configurate::Provider::TOML, 'config/app_config.toml', required: false  # this breaks with 3.2
end
```

```
ArgumentError: wrong number of arguments (given 2, expected 1)
/Users/foxy/src/some_rails_app/config/initializers/00_config.rb:8:in `block in <main>'
/Users/foxy/src/some_rails_app/config/initializers/00_config.rb:6:in `<main>'
/Users/foxy/src/some_rails_app/config/environment.rb:7:in `<main>'
```

Solution: use the argument forwarding operator that was shipped with Ruby 2.7.
If support for older Ruby versions is still a requirement there is also the possibility to use `ruby2_keywords` which was introduced with 2.7 as well, but there is [a compatibility gem for that](https://github.com/ruby/ruby2_keywords).  I created a separate branch with that approach: https://github.com/jhass/configurate/compare/main...nilsding:configurate:ruby2-keywords